### PR TITLE
Fixes get_post_tags() and get_page_tags(), adds article_tags()

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,7 +4,7 @@
 * @return array
 */
 function get_page_tags() {
-  $tag_ext = Extend::where('key', '=', 'page_tags')->where('data_type', '=', 'page')->get();
+  $tag_ext = Extend::where('key', '=', 'page_tags')->where('type', '=', 'page')->get();
   $tag_id = $tag_ext[0]->id;
 
   $prefix = Config::db('prefix', '');
@@ -12,8 +12,8 @@ function get_page_tags() {
   $tags = array();
   $index = 0;
   foreach(Query::table($prefix.'page_meta')
-    ->left_join('pages', 'pages.id', '=', 'page_meta.page')
-    ->where('pages.status', '=', 'published')
+    ->left_join($prefix.'pages', $prefix.'pages.id', '=', $prefix.'page_meta.page')
+    ->where($prefix.'pages.status', '=', 'published')
     ->where('extend', '=', $tag_id)
     ->get() as $meta) {
     $page_meta = json_decode($meta->data);
@@ -56,7 +56,7 @@ function get_pages_with_tag($tag='') {
 * @return array
 */
 function get_post_tags() {
-  $tag_ext = Extend::where('key', '=', 'post_tags')->where('data_type', '=', 'post')->get();
+  $tag_ext = Extend::where('key', '=', 'post_tags')->where('type', '=', 'post')->get();
   $tag_id = $tag_ext[0]->id;
 
   $prefix = Config::db('prefix', '');
@@ -64,8 +64,8 @@ function get_post_tags() {
   $tags = array();
   $index = 0;
   foreach(Query::table($prefix.'post_meta')
-    ->left_join('posts', 'posts.id', '=', 'post_meta.post')
-    ->where('posts.status', '=', 'published')
+    ->left_join($prefix.'posts', $prefix.'posts.id', '=', $prefix.'post_meta.post')
+    ->where($prefix.'posts.status', '=', 'published')
     ->where('extend', '=', $tag_id)
     ->get() as $meta) {
     $post_meta = json_decode($meta->data);

--- a/functions.php
+++ b/functions.php
@@ -166,3 +166,15 @@ function tagged_posts() {
 
   return false;
 }
+
+/**
+ * Returns a (possible empty) list of tags for the current post
+ *
+ * @return array
+ */
+function article_tags() {
+  if ($tags = article_custom_field('post_tags')) {
+    return explode(' ', $tags);
+  }
+  return Array();
+}


### PR DESCRIPTION
1. Added proper use of $prefix when fetch tags via `get_post_tags()` and `get_page_tags()` (fixed some trailing issues from 457f46de).
2. Fixed incorrect usage of "data_type" instead of "type" when specifically selecting either posts or pages.
3. Added new `article_tags()` function that can be used as follow:
```
        <div class="container-fluid">
        <?php foreach(article_tags() as $tag) { ?>
            <a class="label label-primary" href="<?= base_url('') . '?tag=' . $tag; ?>"><?= $tag ?></a>
        <?php } ?>
        </div>
```